### PR TITLE
Added struct tag optional for gohcl

### DIFF
--- a/gohcl/decode_test.go
+++ b/gohcl/decode_test.go
@@ -54,7 +54,17 @@ func TestDecodeBody(t *testing.T) {
 				Name *string `hcl:"name"`
 			}{}),
 			0,
-		},
+		}, // name nil
+		{
+			map[string]interface{}{},
+			struct {
+				Name string `hcl:"name,optional"`
+			}{},
+			deepEquals(struct {
+				Name string `hcl:"name,optional"`
+			}{}),
+			0,
+		}, // name optional
 		{
 			map[string]interface{}{},
 			withNameExpression{},

--- a/gohcl/schema_test.go
+++ b/gohcl/schema_test.go
@@ -193,6 +193,20 @@ func TestImpliedBodySchema(t *testing.T) {
 			},
 			false,
 		},
+		{
+			struct {
+				Meh string `hcl:"meh,optional"`
+			}{},
+			&hcl.BodySchema{
+				Attributes: []hcl.AttributeSchema{
+					{
+						Name:     "meh",
+						Required: false,
+					},
+				},
+			},
+			false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Added `optional` tag for attributes on structs.  In the following example, MiddleName is marked as optional and after decoding the field `MiddleName` on the Person object would be an empty string.  For situations where HCL is used for configuration optional rather than a pointer is more explicit.  It allows parsing of config with validation without needing to mix value and reference types for simple objects.

```go
struct Person struct {
  FirstName     string `hcl:"first_name"`
  MiddleName string `hcl:"middle_name,optional"`
  Surname       string `hcl:"surname"`
}
```

```hcl
person {
  first_name = "Nic"
  surname    = "Jackson"
}
```

I was not sure where to place the docs for this, happy to add docs as an additional commit.

Signed-off-by: nicholasjackson <jackson.nic@gmail.com>