### PR TITLE
hclwriter/parser: fix parsing blocks with labels

### DIFF
--- a/hclwrite/parser.go
+++ b/hclwrite/parser.go
@@ -278,7 +278,10 @@ func parseBlock(nativeBlock *hclsyntax.Block, from, leadComments, lineComments, 
 		}
 		seq := labelTokens.Seq()
 		block.LabelTokens = append(block.LabelTokens, seq)
-		*(block.LabelTokensFlat) = append(*(block.LabelTokensFlat), seq)
+
+		if block.LabelTokensFlat != nil {
+			*(block.LabelTokensFlat) = append(*(block.LabelTokensFlat), seq)
+		}
 		allTokens = append(allTokens, seq)
 	}
 

--- a/hclwrite/parser_test.go
+++ b/hclwrite/parser_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/hashicorp/hcl2/hcl/hclsyntax"
 	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcl/hclsyntax"
 	"github.com/kylelemons/godebug/pretty"
 )
 
@@ -612,6 +612,183 @@ func TestParse(t *testing.T) {
 								{
 									Type:         hclsyntax.TokenIdent,
 									Bytes:        []byte(`b`),
+									SpacesBefore: 0,
+								},
+							},
+						},
+						&TokenSeq{
+							Tokens{
+								{
+									Type:         hclsyntax.TokenOBrace,
+									Bytes:        []byte(`{`),
+									SpacesBefore: 1,
+								},
+							},
+						},
+						(*TokenSeq)(nil), // the empty body
+						&TokenSeq{
+							Tokens{
+								{
+									Type:         hclsyntax.TokenCBrace,
+									Bytes:        []byte(`}`),
+									SpacesBefore: 0,
+								},
+							},
+						},
+						&TokenSeq{
+							Tokens{
+								{
+									Type:         hclsyntax.TokenNewline,
+									Bytes:        []byte{'\n'},
+									SpacesBefore: 0,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"b \"a\" {}\n",
+			&Body{
+				Items: []Node{
+					&Block{
+						AllTokens: &TokenSeq{
+							&TokenSeq{
+								Tokens{
+									{
+										Type:         hclsyntax.TokenIdent,
+										Bytes:        []byte(`b`),
+										SpacesBefore: 0,
+									},
+								},
+							},
+							&TokenSeq{
+								Tokens{
+									{
+										Type:         hclsyntax.TokenOQuote,
+										Bytes:        []byte(`"`),
+										SpacesBefore: 1,
+									},
+									{
+										Type:         hclsyntax.TokenQuotedLit,
+										Bytes:        []byte(`a`),
+										SpacesBefore: 0,
+									},
+									{
+										Type:         hclsyntax.TokenCQuote,
+										Bytes:        []byte(`"`),
+										SpacesBefore: 0,
+									},
+								},
+							},
+							&TokenSeq{
+								Tokens{
+									{
+										Type:         hclsyntax.TokenOBrace,
+										Bytes:        []byte(`{`),
+										SpacesBefore: 1,
+									},
+								},
+							},
+							(*TokenSeq)(nil), // the empty body
+							&TokenSeq{
+								Tokens{
+									{
+										Type:         hclsyntax.TokenCBrace,
+										Bytes:        []byte(`}`),
+										SpacesBefore: 0,
+									},
+								},
+							},
+							&TokenSeq{
+								Tokens{
+									{
+										Type:         hclsyntax.TokenNewline,
+										Bytes:        []byte{'\n'},
+										SpacesBefore: 0,
+									},
+								},
+							},
+						},
+						TypeTokens: &TokenSeq{Tokens{
+							{
+								Type:         hclsyntax.TokenIdent,
+								Bytes:        []byte(`b`),
+								SpacesBefore: 0,
+							},
+						}},
+						LabelTokens: []*TokenSeq{
+							&TokenSeq{
+								Tokens{
+									{
+										Type:         hclsyntax.TokenOQuote,
+										Bytes:        []byte(`"`),
+										SpacesBefore: 1,
+									},
+									{
+										Type:         hclsyntax.TokenQuotedLit,
+										Bytes:        []byte(`a`),
+										SpacesBefore: 0,
+									},
+									{
+										Type:         hclsyntax.TokenCQuote,
+										Bytes:        []byte(`"`),
+										SpacesBefore: 0,
+									},
+								},
+							},
+						},
+						OBraceTokens: &TokenSeq{Tokens{
+							{
+								Type:         hclsyntax.TokenOBrace,
+								Bytes:        []byte(`{`),
+								SpacesBefore: 1,
+							},
+						}},
+						Body: &Body{},
+						CBraceTokens: &TokenSeq{Tokens{
+							{
+								Type:         hclsyntax.TokenCBrace,
+								Bytes:        []byte(`}`),
+								SpacesBefore: 0,
+							},
+						}},
+						EOLTokens: &TokenSeq{Tokens{
+							{
+								Type:         hclsyntax.TokenNewline,
+								Bytes:        []byte{'\n'},
+								SpacesBefore: 0,
+							},
+						}},
+					},
+				},
+				AllTokens: &TokenSeq{
+					&TokenSeq{
+						&TokenSeq{
+							Tokens{
+								{
+									Type:         hclsyntax.TokenIdent,
+									Bytes:        []byte(`b`),
+									SpacesBefore: 0,
+								},
+							},
+						},
+						&TokenSeq{
+							Tokens{
+								{
+									Type:         hclsyntax.TokenOQuote,
+									Bytes:        []byte(`"`),
+									SpacesBefore: 1,
+								},
+								{
+									Type:         hclsyntax.TokenQuotedLit,
+									Bytes:        []byte(`a`),
+									SpacesBefore: 0,
+								},
+								{
+									Type:         hclsyntax.TokenCQuote,
+									Bytes:        []byte(`"`),
 									SpacesBefore: 0,
 								},
 							},


### PR DESCRIPTION
There was no test case for parsing a block with a label. If you run the
test without the fix you'll see that it panics because LabelTokensFlat
is empty.