### PR TITLE
Improve error output when diagnostic's subject is nil

### DIFF
--- a/hcl/diagnostic.go
+++ b/hcl/diagnostic.go
@@ -74,6 +74,9 @@ type Diagnostics []*Diagnostic
 // This presents only minimal context about the error, for compatibility
 // with usual expectations about how errors will present as strings.
 func (d *Diagnostic) Error() string {
+	if d.Subject == nil {
+		return fmt.Sprintf("%s; %s", d.Summary, d.Detail)
+	}
 	return fmt.Sprintf("%s: %s; %s", d.Subject, d.Summary, d.Detail)
 }
 


### PR DESCRIPTION
When using Terraform as a library, I noticed that when the Subject of `hcl.diagnotic` is nil, it returns unnatural error output like the following:

```
<nil>: Failed to read file; The file "example1.tfvars" could not be read.
```

Errors that failed to read the file naturally have no `hcl.Range`. In such a case, I think that it should not include the Subject in error message. What do you think?