### PR TITLE
hclsyntax: Add test for 'func()[idx]' syntax

### DIFF
--- a/hcl/hclsyntax/parser_test.go
+++ b/hcl/hclsyntax/parser_test.go
@@ -1956,6 +1956,140 @@ block "valid" {}
 				},
 			},
 		},
+		{
+			"a = sort(data.first.ref.attr)[count.index]\n",
+			0,
+			&Body{
+				Attributes: Attributes{
+					"a": {
+						Name: "a",
+						Expr: &IndexExpr{
+							Collection: &FunctionCallExpr{
+								Name: "sort",
+								Args: []Expression{
+									&ScopeTraversalExpr{
+										Traversal: hcl.Traversal{
+											hcl.TraverseRoot{
+												Name: "data",
+												SrcRange: hcl.Range{
+													Filename: "",
+													Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+													End:      hcl.Pos{Line: 1, Column: 14, Byte: 13},
+												},
+											},
+											hcl.TraverseAttr{
+												Name: "first",
+												SrcRange: hcl.Range{
+													Filename: "",
+													Start:    hcl.Pos{Line: 1, Column: 14, Byte: 13},
+													End:      hcl.Pos{Line: 1, Column: 20, Byte: 19},
+												},
+											},
+											hcl.TraverseAttr{
+												Name: "ref",
+												SrcRange: hcl.Range{
+													Filename: "",
+													Start:    hcl.Pos{Line: 1, Column: 20, Byte: 19},
+													End:      hcl.Pos{Line: 1, Column: 24, Byte: 23},
+												},
+											},
+											hcl.TraverseAttr{
+												Name: "attr",
+												SrcRange: hcl.Range{
+													Filename: "",
+													Start:    hcl.Pos{Line: 1, Column: 24, Byte: 23},
+													End:      hcl.Pos{Line: 1, Column: 29, Byte: 28},
+												},
+											},
+										},
+										SrcRange: hcl.Range{
+											Filename: "",
+											Start:    hcl.Pos{Line: 1, Column: 10, Byte: 9},
+											End:      hcl.Pos{Line: 1, Column: 29, Byte: 28},
+										},
+									},
+								},
+								ExpandFinal: false,
+								NameRange: hcl.Range{
+									Filename: "",
+									Start:    hcl.Pos{Line: 1, Column: 5, Byte: 4},
+									End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+								},
+								OpenParenRange: hcl.Range{
+									Filename: "",
+									Start:    hcl.Pos{Line: 1, Column: 9, Byte: 8},
+									End:      hcl.Pos{Line: 1, Column: 10, Byte: 9},
+								},
+								CloseParenRange: hcl.Range{
+									Filename: "",
+									Start:    hcl.Pos{Line: 1, Column: 29, Byte: 28},
+									End:      hcl.Pos{Line: 1, Column: 30, Byte: 29},
+								},
+							},
+							Key: &ScopeTraversalExpr{
+								Traversal: hcl.Traversal{
+									hcl.TraverseRoot{
+										Name: "count",
+										SrcRange: hcl.Range{
+											Filename: "",
+											Start:    hcl.Pos{Line: 1, Column: 31, Byte: 30},
+											End:      hcl.Pos{Line: 1, Column: 36, Byte: 35},
+										},
+									},
+									hcl.TraverseAttr{
+										Name: "index",
+										SrcRange: hcl.Range{
+											Filename: "",
+											Start:    hcl.Pos{Line: 1, Column: 36, Byte: 35},
+											End:      hcl.Pos{Line: 1, Column: 42, Byte: 41},
+										},
+									},
+								},
+								SrcRange: hcl.Range{
+									Filename: "",
+									Start:    hcl.Pos{Line: 1, Column: 31, Byte: 30},
+									End:      hcl.Pos{Line: 1, Column: 42, Byte: 41},
+								},
+							},
+							SrcRange: hcl.Range{
+								Filename: "",
+								Start:    hcl.Pos{Line: 1, Column: 30, Byte: 29},
+								End:      hcl.Pos{Line: 1, Column: 43, Byte: 42},
+							},
+							OpenRange: hcl.Range{
+								Filename: "",
+								Start:    hcl.Pos{Line: 1, Column: 30, Byte: 29},
+								End:      hcl.Pos{Line: 1, Column: 31, Byte: 30},
+							},
+						},
+						SrcRange: hcl.Range{
+							Filename: "",
+							Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:      hcl.Pos{Line: 1, Column: 43, Byte: 42},
+						},
+						NameRange: hcl.Range{
+							Filename: "",
+							Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:      hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						},
+						EqualsRange: hcl.Range{
+							Filename: "",
+							Start:    hcl.Pos{Line: 1, Column: 3, Byte: 2},
+							End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+						},
+					},
+				},
+				Blocks: Blocks{},
+				SrcRange: hcl.Range{
+					Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+					End:   hcl.Pos{Line: 2, Column: 1, Byte: 43},
+				},
+				EndRange: hcl.Range{
+					Start: hcl.Pos{Line: 2, Column: 1, Byte: 43},
+					End:   hcl.Pos{Line: 2, Column: 1, Byte: 43},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/hcl/hclsyntax/parser_test.go
+++ b/hcl/hclsyntax/parser_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+func init() {
+	deep.MaxDepth = 999
+}
+
 func TestParseConfig(t *testing.T) {
 	tests := []struct {
 		input     string
@@ -1393,8 +1397,8 @@ block "valid" {}
 									Val: cty.StringVal("Hello\n"),
 
 									SrcRange: hcl.Range{
-										Start: hcl.Pos{Line: 1, Column: 6, Byte: 5},
-										End:   hcl.Pos{Line: 1, Column: 12, Byte: 11},
+										Start: hcl.Pos{Line: 2, Column: 1, Byte: 10},
+										End:   hcl.Pos{Line: 3, Column: 1, Byte: 16},
 									},
 								},
 							},
@@ -1426,8 +1430,8 @@ block "valid" {}
 									Val: cty.StringVal("Hi"),
 
 									SrcRange: hcl.Range{
-										Start: hcl.Pos{Line: 4, Column: 24, Byte: 5},
-										End:   hcl.Pos{Line: 4, Column: 9, Byte: 28},
+										Start: hcl.Pos{Line: 4, Column: 6, Byte: 25},
+										End:   hcl.Pos{Line: 4, Column: 8, Byte: 27},
 									},
 								},
 							},
@@ -1550,8 +1554,8 @@ block "valid" {}
 									Name: "baz",
 
 									SrcRange: hcl.Range{
-										Start: hcl.Pos{Line: 1, Column: 8, Byte: 7},
-										End:   hcl.Pos{Line: 1, Column: 12, Byte: 11},
+										Start: hcl.Pos{Line: 1, Column: 12, Byte: 11},
+										End:   hcl.Pos{Line: 1, Column: 16, Byte: 15},
 									},
 								},
 							},

--- a/hcl/json/parser_test.go
+++ b/hcl/json/parser_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/hashicorp/hcl2/hcl"
 )
 
+func init() {
+	deep.MaxDepth = 999
+}
+
 func TestParse(t *testing.T) {
 	tests := []struct {
 		Input     string


### PR DESCRIPTION
`github.com/go-test/deep` has pretty low default settings for how deeply it should inspect nested structures. As an effect we were silently ignoring some differences.

Also see https://github.com/go-test/deep/issues/17

I'm not sure if there's a better way/place where to set `MaxDepth` or whether this depth is appropriate, it's just an arbitrary number.
I'm open to suggestions.

I'm also adding a test which I used to invalidate my assumption that we parse `func()[idx]` incorrectly - i.e. there is nothing to fix, but I just thought it would be useful to have such test in place for the future, just in case.