### PR TITLE
hcl/merged: Fix PartialContent used on merged bodies

### DIFF
--- a/hcl/merged.go
+++ b/hcl/merged.go
@@ -171,7 +171,7 @@ func (mb mergedBodies) mergedContent(schema *BodySchema, partial bool) (*BodyCon
 		}
 
 		if thisLeftovers != nil {
-			mergedLeftovers = append(mergedLeftovers)
+			mergedLeftovers = append(mergedLeftovers, thisLeftovers)
 		}
 		if len(thisDiags) != 0 {
 			diags = append(diags, thisDiags...)


### PR DESCRIPTION
The `mergedLeftovers` slice wasn't being appended with anything so the remaining content after a `PartialContent` was empty. I also added some test cases to cover the change.