### PR TITLE
hclpack: fix missing range on remaining body

### DIFF
--- a/hclpack/structure.go
+++ b/hclpack/structure.go
@@ -36,7 +36,9 @@ func (b *Body) Content(schema *hcl.BodySchema) (*hcl.BodyContent, hcl.Diagnostic
 // so callers can type-assert to obtain a child Body in order to serialize it
 // separately if needed.
 func (b *Body) PartialContent(schema *hcl.BodySchema) (*hcl.BodyContent, hcl.Body, hcl.Diagnostics) {
-	remain := &Body{}
+	remain := &Body{
+		MissingItemRange_: b.MissingItemRange_,
+	}
 	content, diags := b.content(schema, remain)
 	return content, remain, diags
 }

--- a/hclpack/structure_test.go
+++ b/hclpack/structure_test.go
@@ -91,3 +91,43 @@ func TestBodyContent(t *testing.T) {
 	}
 
 }
+
+func TestBodyPartialContent(t *testing.T) {
+	tests := map[string]struct {
+		Body       *Body
+		Schema     *hcl.BodySchema
+		WantRemain hcl.Body
+	}{
+		"missing range": {
+			&Body{
+				MissingItemRange_: hcl.Range{
+					Filename: "file.hcl",
+					Start:    hcl.Pos{Line: 3, Column: 2},
+					End:      hcl.Pos{Line: 3, Column: 2},
+				},
+			},
+			&hcl.BodySchema{},
+			&Body{
+				MissingItemRange_: hcl.Range{
+					Filename: "file.hcl",
+					Start:    hcl.Pos{Line: 3, Column: 2},
+					End:      hcl.Pos{Line: 3, Column: 2},
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, gotRemain, diags := test.Body.PartialContent(test.Schema)
+			for _, diag := range diags {
+				t.Errorf("unexpected diagnostic: %s", diag.Error())
+			}
+
+			if !cmp.Equal(test.WantRemain, gotRemain) {
+				t.Errorf("wrong remaining result\n%s", cmp.Diff(test.WantRemain, gotRemain))
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Fixes setting the MissingItemRange on the remaining body when a
`*hclpack.Body` is partially decoded. Otherwise when the remaining body is
decoded with missing fields, the diagnostic cannot point to where they
should be set.