### PR TITLE
hclpack: fix marshalling binary file index positions

### DIFF
--- a/hclpack/positions_packed.go
+++ b/hclpack/positions_packed.go
@@ -28,6 +28,7 @@ func (pp positionsPacked) MarshalBinary() ([]byte, error) {
 		// for a body to be entirely in one file, this can lead to considerable
 		// savings in that case.
 		delims := ppr.FileIdx - lastFileIdx
+		lastFileIdx = ppr.FileIdx
 		for i := 0; i < delims; i++ {
 			buf = buf.AppendRawByte(';')
 		}
@@ -65,6 +66,7 @@ func (pp *positionsPacked) UnmarshalBinary(data []byte) error {
 
 		var ppr positionPacked
 		var err error
+		ppr.FileIdx = fileIdx
 		ppr.LineDelta, buf, err = buf.ReadInt()
 		if err != nil {
 			return err

--- a/hclpack/positions_packed_test.go
+++ b/hclpack/positions_packed_test.go
@@ -1,0 +1,30 @@
+package hclpack
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestBinaryRoundTrip(t *testing.T) {
+	startPacked := positionsPacked{
+		{FileIdx: 0, LineDelta: 1, ColumnDelta: 2, ByteDelta: 3},
+		{FileIdx: 1, LineDelta: 2, ColumnDelta: 3, ByteDelta: 4},
+		{FileIdx: 2, LineDelta: 3, ColumnDelta: 4, ByteDelta: 5},
+	}
+
+	b, err := startPacked.MarshalBinary()
+	if err != nil {
+		t.Fatalf("Failed to marshal: %s", err)
+	}
+
+	var endPacked positionsPacked
+	err = endPacked.UnmarshalBinary(b)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal: %s", err)
+	}
+
+	if !cmp.Equal(startPacked, endPacked) {
+		t.Errorf("Incorrect result\n%s", cmp.Diff(startPacked, endPacked))
+	}
+}


### PR DESCRIPTION
When marshalling positions into binary, the current file index was not stored. Because of this, a `;` was inserted multiple times for each file, even if the file did not change.

When unmarshalling, the `fileIdx` determined by number of `;` was ignored. Thus, if there were more than one file, all the positions would still point to the first file.

This was likely intended to be there in the first place but was just missed.