### PR TITLE
hclwrite: fix space being added between interpolated items

### DIFF
--- a/hclwrite/format.go
+++ b/hclwrite/format.go
@@ -325,6 +325,10 @@ func spaceAfterToken(subject, before, after *Token) bool {
 	case subject.Type == hclsyntax.TokenCBrace && after.Type == hclsyntax.TokenTemplateSeqEnd:
 		return true
 
+	// Don't add spaces between interpolated items
+	case subject.Type == hclsyntax.TokenTemplateSeqEnd && after.Type == hclsyntax.TokenTemplateInterp:
+		return false
+
 	case tokenBracketChange(subject) > 0:
 		// No spaces after open brackets
 		return false

--- a/hclwrite/format_test.go
+++ b/hclwrite/format_test.go
@@ -72,6 +72,10 @@ func TestFormat(t *testing.T) {
 			`a = "hello ${~name~}"`,
 		},
 		{
+			`a="${b}${c}${ d } ${e}"`,
+			`a = "${b}${c}${d} ${e}"`,
+		},
+		{
 			`b{}`,
 			`b {}`,
 		},
@@ -498,6 +502,22 @@ EOT
 foo {
   bar = <<-EOT
   ${ { blahblahblah = x } }
+EOT
+}
+`,
+		},
+		{
+			`
+foo {
+  bar = <<-EOT
+  ${a}${b}${ c } ${d}
+EOT
+}
+`,
+			`
+foo {
+  bar = <<-EOT
+  ${a}${b}${c} ${d}
 EOT
 }
 `,


### PR DESCRIPTION
closes #65
- add missing edge case for two interpolated items next to each other
- add tests for both quote and heredoc cases