### PR TITLE
hcl/hclsyntax: Improve error reporting for comma-separated args

### DIFF
--- a/hcl/hclsyntax/parser.go
+++ b/hcl/hclsyntax/parser.go
@@ -236,10 +236,18 @@ func (p *parser) finishParsingBodyAttribute(ident Token, singleLine bool) (Node,
 			end := p.Peek()
 			if end.Type != TokenNewline && end.Type != TokenEOF {
 				if !p.recovery {
+					summary := "Missing newline after argument"
+					detail := "An argument definition must end with a newline."
+
+					if end.Type == TokenComma {
+						summary = "Unexpected comma after argument"
+						detail = "Argument definitions must be separated by newlines, not commas. " + detail
+					}
+
 					diags = append(diags, &hcl.Diagnostic{
 						Severity: hcl.DiagError,
-						Summary:  "Missing newline after argument",
-						Detail:   "An argument definition must end with a newline.",
+						Summary:  summary,
+						Detail:   detail,
 						Subject:  &end.Range,
 						Context:  hcl.RangeBetween(ident.Range, end.Range).Ptr(),
 					})

--- a/hcl/hclsyntax/parser_test.go
+++ b/hcl/hclsyntax/parser_test.go
@@ -2031,6 +2031,47 @@ block "valid" {}
 			},
 		},
 		{
+			"a = 1,",
+			1,
+			&Body{
+				Attributes: Attributes{
+					"a": {
+						Name: "a",
+						Expr: &LiteralValueExpr{
+							Val: cty.NumberIntVal(1),
+
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 1, Column: 5, Byte: 4},
+								End:   hcl.Pos{Line: 1, Column: 6, Byte: 5},
+							},
+						},
+
+						SrcRange: hcl.Range{
+							Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:   hcl.Pos{Line: 1, Column: 6, Byte: 5},
+						},
+						NameRange: hcl.Range{
+							Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:   hcl.Pos{Line: 1, Column: 2, Byte: 1},
+						},
+						EqualsRange: hcl.Range{
+							Start: hcl.Pos{Line: 1, Column: 3, Byte: 2},
+							End:   hcl.Pos{Line: 1, Column: 4, Byte: 3},
+						},
+					},
+				},
+				Blocks: Blocks{},
+				SrcRange: hcl.Range{
+					Start: hcl.Pos{Line: 1, Column: 1, Byte: 0},
+					End:   hcl.Pos{Line: 1, Column: 7, Byte: 6},
+				},
+				EndRange: hcl.Range{
+					Start: hcl.Pos{Line: 1, Column: 7, Byte: 6},
+					End:   hcl.Pos{Line: 1, Column: 7, Byte: 6},
+				},
+			},
+		},
+		{
 			"a = sort(data.first.ref.attr)[count.index]\n",
 			0,
 			&Body{


### PR DESCRIPTION
It turns out that some people separate argument definitions with commas even when these are each on new lines.

Here's a [real example](https://github.com/terraform-providers/terraform-provider-fastly/blob/79c4eeba23a8a5ef2753c8404a48ba3bb2a2092b/fastly/resource_fastly_service_v1_bigquerylogging_test.go#L145-L152) I found in acceptance test of the Fastly provider while attempting to upgrade it:

```hcl
resource "fastly_service_v1" "foo" {
  name = "..."

  bigquerylogging {
    name       = "%s"
    email      = "email@example.com",
    secret_key = "secretKey",
    project_id = "example-gcp-project"
    dataset    = "example-bq-dataset"
    table      = "example-bq-table"
  }
}
```

Hence I think this case deserves a special error message.

## Message before patch

![screen shot 2019-01-24 at 11 53 51](https://user-images.githubusercontent.com/287584/51676523-bf9d6c80-1fce-11e9-8079-d8bb970ee715.png)

## Message after patch

![screen shot 2019-01-24 at 11 56 06](https://user-images.githubusercontent.com/287584/51676613-0f7c3380-1fcf-11e9-977a-0a1a0add5ee5.png)
