### PR TITLE
json: Allow null values for block attributes

### DIFF
--- a/hcl/json/structure.go
+++ b/hcl/json/structure.go
@@ -327,6 +327,8 @@ func (b *body) collectDeepAttrs(v node, labelName *string) ([]*objectAttr, hcl.D
 	var attrs []*objectAttr
 
 	switch tv := v.(type) {
+	case *nullVal:
+		// If a value is null, then we don't return any attributes or return an error.
 
 	case *objectVal:
 		attrs = append(attrs, tv.Attrs...)

--- a/hcl/json/structure.go
+++ b/hcl/json/structure.go
@@ -266,6 +266,9 @@ func (b *body) unpackBlock(v node, typeName string, typeRange *hcl.Range, labels
 	copy(labelR, labelRanges)
 
 	switch tv := v.(type) {
+	case *nullVal:
+		// There is no block content, e.g the value is null.
+		return
 	case *objectVal:
 		// Single instance of the block
 		*blocks = append(*blocks, &hcl.Block{

--- a/hcl/json/structure_test.go
+++ b/hcl/json/structure_test.go
@@ -323,6 +323,27 @@ func TestBodyPartialContent(t *testing.T) {
 			0,
 		},
 		{
+			`{"resource": { "nested": null }}`,
+			&hcl.BodySchema{
+				Blocks: []hcl.BlockHeaderSchema{
+					{
+						Type:       "resource",
+						LabelNames: []string{"name"},
+					},
+				},
+			},
+			&hcl.BodyContent{
+				Attributes: map[string]*hcl.Attribute{},
+				Blocks:     nil,
+				MissingItemRange: hcl.Range{
+					Filename: "test.json",
+					Start:    hcl.Pos{Line: 1, Column: 32, Byte: 31},
+					End:      hcl.Pos{Line: 1, Column: 33, Byte: 32},
+				},
+			},
+			0,
+		},
+		{
 			`{"resource":{}}`,
 			&hcl.BodySchema{
 				Blocks: []hcl.BlockHeaderSchema{

--- a/hcl/json/structure_test.go
+++ b/hcl/json/structure_test.go
@@ -302,6 +302,27 @@ func TestBodyPartialContent(t *testing.T) {
 			1,
 		},
 		{
+			`{"resource": null}`,
+			&hcl.BodySchema{
+				Blocks: []hcl.BlockHeaderSchema{
+					{
+						Type: "resource",
+					},
+				},
+			},
+			&hcl.BodyContent{
+				Attributes: map[string]*hcl.Attribute{},
+				// We don't find any blocks if the value is json null.
+				Blocks: nil,
+				MissingItemRange: hcl.Range{
+					Filename: "test.json",
+					Start:    hcl.Pos{Line: 1, Column: 18, Byte: 17},
+					End:      hcl.Pos{Line: 1, Column: 19, Byte: 18},
+				},
+			},
+			0,
+		},
+		{
 			`{"resource":{}}`,
 			&hcl.BodySchema{
 				Blocks: []hcl.BlockHeaderSchema{


### PR DESCRIPTION
This treats `null` JSON values for block attributes as if they were not
specified, for example:

```json
{
    "resource": null,
}
```

will parse as having found no `resource` blocks.