### PR TITLE
json: Eval json null values as cty.Null

### DIFF
--- a/hcl/json/structure.go
+++ b/hcl/json/structure.go
@@ -499,6 +499,8 @@ func (e *expression) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 			return cty.DynamicVal, diags
 		}
 		return cty.ObjectVal(attrs), diags
+	case *nullVal:
+		return cty.NullVal(cty.DynamicPseudoType), nil
 	default:
 		// Default to DynamicVal so that ASTs containing invalid nodes can
 		// still be partially-evaluated.


### PR DESCRIPTION
Evaluate json null values as cty.Null, rather than as unknown value.

Using DynamicPseudoType as the null type as a placeholder for the null
type.  Callers may convert the type against schema to get the concrete
type.