### PR TITLE
hclsyntax: return the starting position of a missing attr, not the end.

### DIFF
--- a/hcl/hclsyntax/structure.go
+++ b/hcl/hclsyntax/structure.go
@@ -279,7 +279,11 @@ func (b *Body) JustAttributes() (hcl.Attributes, hcl.Diagnostics) {
 }
 
 func (b *Body) MissingItemRange() hcl.Range {
-	return b.EndRange
+	return hcl.Range{
+		Filename: b.SrcRange.Filename,
+		Start:    b.SrcRange.Start,
+		End:      b.SrcRange.Start,
+	}
 }
 
 // Attributes is the collection of attribute definitions within a body.


### PR DESCRIPTION
Previously, `hclsyntax` `MissingItemRange()` function returned a zero-length
range anchored at the end of the block in question. This commit changes
that to the beginning of the block. In practice, the end of a block is
generally just a "}" and not very useful in error messages.

Fixes #93