### PR TITLE
hclpack: Fix name range for unsupported attribute

### DIFF
--- a/hclpack/structure.go
+++ b/hclpack/structure.go
@@ -101,11 +101,12 @@ func (b *Body) content(schema *hcl.BodySchema, remain *Body) (*hcl.BodyContent, 
 				}
 			}
 		}
+
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Unsupported argument",
 			Detail:   fmt.Sprintf("An argument named %q is not expected here.%s", name, suggestion),
-			Subject:  &attr.NameRange,
+			Subject:  attr.NameRange.Ptr(),
 		})
 	}
 


### PR DESCRIPTION
Fixes an issue where the name range may be incorrect in case there are multiple attributes and one of them is wrong. Another attribute's name range could overwrite the previous one as the attr variable is overwritten in the for loop.

The fix is essentially the same as https://github.com/hashicorp/hcl2/pull/73

_Note: there are no tests for this but that's mostly because there were no existing tests for checking diagnostics._