### PR TITLE
Fix incorrect alphabetical check in json scanner

### DIFF
--- a/hcl/json/scanner.go
+++ b/hcl/json/scanner.go
@@ -153,7 +153,7 @@ func byteCanStartKeyword(b byte) bool {
 	// in the parser, where we can generate better diagnostics.
 	// So e.g. we want to be able to say:
 	//   unrecognized keyword "True". Did you mean "true"?
-	case b >= 'a' || b <= 'z' || b >= 'A' || b <= 'Z':
+	case isAlphabetical(b):
 		return true
 	default:
 		return false
@@ -167,7 +167,7 @@ Byte:
 	for i = 0; i < len(buf); i++ {
 		b := buf[i]
 		switch {
-		case (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_':
+		case isAlphabetical(b) || b == '_':
 			p.Pos.Byte++
 			p.Pos.Column++
 		default:
@@ -290,4 +290,8 @@ func posRange(start, end pos) hcl.Range {
 
 func (t token) GoString() string {
 	return fmt.Sprintf("json.token{json.%s, []byte(%q), %#v}", t.Type, t.Bytes, t.Range)
+}
+
+func isAlphabetical(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }

--- a/hcl/json/scanner_test.go
+++ b/hcl/json/scanner_test.go
@@ -810,6 +810,27 @@ func TestScan(t *testing.T) {
 				},
 			},
 		},
+		{
+			`&`,
+			[]token{
+				{
+					Type:  tokenInvalid,
+					Bytes: []byte(`&`),
+					Range: hcl.Range{
+						Start: hcl.Pos{
+							Byte:   0,
+							Line:   1,
+							Column: 1,
+						},
+						End: hcl.Pos{
+							Byte:   1,
+							Line:   1,
+							Column: 2,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
There is a bug in json scanner while scanning an ill-formed document like this one:
```json
&
```
The scanner hangs in infinite loop, and, sometimes panics with memory allocation error.

The reason is the `byteCanStartNumber`  function (`hcl/json/scanner.go`), where alphabetical character check is performed like this:
```go
case b >= 'a' || b <= 'z' || b >= 'A' || b <= 'Z':
    return true
```

The check passes for any character, but only ill-formed documents are affected by this, because the scan function tries to scan a keyword after all other lexemmes. The result is that the scanKeyword function returns a token of zero length and slice nothing from the buffer. The buffer remains the same and on the next iteration a keyword will be scanned again, yielding an infinite loop.

I've fixed that and added a new test input (in TestScan function in `hcl/json/scanner_test.go`) for such a document (expecting one invalid token as the output).
Also, I've refactored the check a little bit so it guarantees that the set of valid first characters of a keyword is a subset of all valid characters of a keyword (the set of all valid characters also includes underscore `'_'`).