### PR TITLE
hclwrite: Fix improper indent calculation inside heredocs

### DIFF
--- a/hclwrite/format.go
+++ b/hclwrite/format.go
@@ -54,20 +54,10 @@ func formatIndent(lines []formatLine) {
 	// which should be more than enough for reasonable HCL uses.
 	indents := make([]int, 0, 10)
 
-	inHeredoc := false
 	for i := range lines {
 		line := &lines[i]
 		if len(line.lead) == 0 {
 			continue
-		}
-
-		if inHeredoc {
-			for _, token := range line.lead {
-				if token.Type == hclsyntax.TokenCHeredoc {
-					inHeredoc = false
-				}
-			}
-			continue // don't touch indentation inside heredocs
 		}
 
 		if line.lead[0].Type == hclsyntax.TokenNewline {
@@ -80,9 +70,10 @@ func formatIndent(lines []formatLine) {
 		for _, token := range line.lead {
 			netBrackets += tokenBracketChange(token)
 			if token.Type == hclsyntax.TokenOHeredoc {
-				inHeredoc = true
+				break
 			}
 		}
+
 		for _, token := range line.assign {
 			netBrackets += tokenBracketChange(token)
 		}

--- a/hclwrite/format_test.go
+++ b/hclwrite/format_test.go
@@ -550,6 +550,36 @@ baz {
 }
 `,
 		},
+		{
+			`
+foo {
+bar = <<EOT
+Foo bar baz
+EOT
+baz = <<EOT
+Foo bar baz
+EOT
+}
+
+bar {
+foo = "bar"
+}
+`,
+			`
+foo {
+  bar = <<EOT
+Foo bar baz
+EOT
+  baz = <<EOT
+Foo bar baz
+EOT
+}
+
+bar {
+  foo = "bar"
+}
+`,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Potential fix for #106.

`linesForFormat` function already put all tokens in one heredoc into one `formatLine` instance, so `formatIndent` function does not need to go through multiple lines to find the corresponding `TokenCHeredoc`. Instead, it can just ignore the whole line.