### PR TITLE
Support gohcl.Encode for hcl.Attributes tagged with 'hcl:",remain"'

### DIFF
--- a/gohcl/encode_test.go
+++ b/gohcl/encode_test.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl2/gohcl"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/hcl2/hcl/hclsyntax"
 	"github.com/hashicorp/hcl2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func ExampleEncodeIntoBody() {
@@ -16,11 +19,15 @@ func ExampleEncodeIntoBody() {
 		OS   string `hcl:"os"`
 		Arch string `hcl:"arch"`
 	}
+	type Locals struct {
+		Definitions hcl.Attributes `hcl:",remain"`
+	}
 	type App struct {
 		Name        string       `hcl:"name"`
 		Desc        string       `hcl:"description"`
 		Constraints *Constraints `hcl:"constraints,block"`
 		Services    []Service    `hcl:"service,block"`
+		Locals      []*Locals    `hcl:"locals,block"`
 	}
 
 	app := App{
@@ -38,6 +45,26 @@ func ExampleEncodeIntoBody() {
 			{
 				Name: "worker",
 				Exe:  []string{"./worker"},
+			},
+		},
+		Locals: []*Locals{
+			&Locals{
+				Definitions: hcl.Attributes{
+					"hello": &hcl.Attribute{
+						Name: "hello",
+						Expr: hcl.StaticExpr(cty.StringVal("world"), hcl.Range{}),
+					},
+					"foo": &hcl.Attribute{
+						Name: "foo",
+						Expr: &hclsyntax.ScopeTraversalExpr{
+							Traversal: hcl.Traversal{
+								hcl.TraverseRoot{
+									Name: "bar",
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -60,5 +87,10 @@ func ExampleEncodeIntoBody() {
 	// }
 	// service "worker" {
 	//   executable = ["./worker"]
+	// }
+	//
+	// locals {
+	//   hello = "world"
+	//   foo   = bar
 	// }
 }

--- a/gohcl/schema.go
+++ b/gohcl/schema.go
@@ -109,11 +109,12 @@ func ImpliedBodySchema(val interface{}) (schema *hcl.BodySchema, partial bool) {
 }
 
 type fieldTags struct {
-	Attributes map[string]int
-	Blocks     map[string]int
-	Labels     []labelField
-	Remain     *int
-	Optional   map[string]bool
+	Attributes  map[string]int
+	Blocks      map[string]int
+	Labels      []labelField
+	Remain      *int
+	RemainField string
+	Optional    map[string]bool
 }
 
 type labelField struct {
@@ -162,6 +163,7 @@ func getFieldTags(ty reflect.Type) *fieldTags {
 			}
 			idx := i // copy, because this loop will continue assigning to i
 			ret.Remain = &idx
+			ret.RemainField = field.Name
 		case "optional":
 			ret.Attributes[name] = i
 			ret.Optional[name] = true


### PR DESCRIPTION
I noticed that gohcl is ignoring the content of a terraform `locals` block.
This patch prints the `locals` block with its set of arbitrary named expressions.

Let me know if this is something you would plan to support here or if I should refactor this on its own.
Happy to refactor it and beef it up or even attempt to complete the work to support "hcl:'remain'" for an `hcl.Body` with your guidance.