### PR TITLE
return array value evaluation diagnostics

### DIFF
--- a/hcl/json/structure.go
+++ b/hcl/json/structure.go
@@ -416,12 +416,14 @@ func (e *expression) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	case *booleanVal:
 		return cty.BoolVal(v.Value), nil
 	case *arrayVal:
+		var diags hcl.Diagnostics
 		vals := []cty.Value{}
 		for _, jsonVal := range v.Values {
-			val, _ := (&expression{src: jsonVal}).Value(ctx)
+			val, valDiags := (&expression{src: jsonVal}).Value(ctx)
 			vals = append(vals, val)
+			diags = append(diags, valDiags...)
 		}
-		return cty.TupleVal(vals), nil
+		return cty.TupleVal(vals), diags
 	case *objectVal:
 		var diags hcl.Diagnostics
 		attrs := map[string]cty.Value{}


### PR DESCRIPTION
Fix a bug where diagnostics found when evaluating array individual
elements are ignored, resulting in suppressed errors.

Nomad observed this issue in https://github.com/hashicorp/nomad/issues/5694.