### PR TITLE
hclsyntax: Parse indexing brackets with a string literal as a traversal

### DIFF
--- a/hcl/hclsyntax/expression_template.go
+++ b/hcl/hclsyntax/expression_template.go
@@ -89,6 +89,26 @@ func (e *TemplateExpr) StartRange() hcl.Range {
 	return e.Parts[0].StartRange()
 }
 
+// IsStringLiteral returns true if and only if the template consists only of
+// single string literal, as would be created for a simple quoted string like
+// "foo".
+//
+// If this function returns true, then calling Value on the same expression
+// with a nil EvalContext will return the literal value.
+//
+// Note that "${"foo"}", "${1}", etc aren't considered literal values for the
+// purposes of this method, because the intent of this method is to identify
+// situations where the user seems to be explicitly intending literal string
+// interpretation, not situations that result in literals as a technicality
+// of the template expression unwrapping behavior.
+func (e *TemplateExpr) IsStringLiteral() bool {
+	if len(e.Parts) != 1 {
+		return false
+	}
+	_, ok := e.Parts[0].(*LiteralValueExpr)
+	return ok
+}
+
 // TemplateJoinExpr is used to convert tuples of strings produced by template
 // constructs (i.e. for loops) into flat strings, by converting the values
 // tos strings and joining them. This AST node is not used directly; it's

--- a/hcl/hclsyntax/parser.go
+++ b/hcl/hclsyntax/parser.go
@@ -853,6 +853,14 @@ Traversal:
 						SrcRange: rng,
 					}
 					ret = makeRelativeTraversal(ret, step, rng)
+				} else if tmpl, isTmpl := keyExpr.(*TemplateExpr); isTmpl && tmpl.IsStringLiteral() {
+					litKey, _ := tmpl.Value(nil)
+					rng := hcl.RangeBetween(open.Range, close.Range)
+					step := hcl.TraverseIndex{
+						Key:      litKey,
+						SrcRange: rng,
+					}
+					ret = makeRelativeTraversal(ret, step, rng)
 				} else {
 					rng := hcl.RangeBetween(open.Range, close.Range)
 					ret = &IndexExpr{

--- a/hcl/traversal_for_expr.go
+++ b/hcl/traversal_for_expr.go
@@ -36,7 +36,7 @@ func AbsTraversalForExpr(expr Expression) (Traversal, Diagnostics) {
 		&Diagnostic{
 			Severity: DiagError,
 			Summary:  "Invalid expression",
-			Detail:   "A static variable reference is required.",
+			Detail:   "A single static variable reference is required: only attribute access and indexing with constant keys. No calculations, function calls, template expressions, etc are allowed here.",
 			Subject:  expr.Range().Ptr(),
 		},
 	}


### PR DESCRIPTION
A sequence like `"foo"` is represented in the AST as a `TemplateExpr` with a single string literal inside rather than as a string literal node directly, so we need to recognize that situation during parsing and treat it as a special case so we can get the intended behavior of representing that index as a traversal step rather than as a dynamic index operation.

Most of the time this distinction doesn't matter, but it's important for static analysis use-cases. In particular, `hcl.AbsTraversalForExpr` will now accept an expression like `foo["bar"]` where before it would've rejected it.

This also includes a better error message for when an expression cannot be recognized as a single traversal. There isn't really any context here to return a direct reference to the construct that was problematic, which is what we'd ideally do, but at least this new message includes a summary of what is allowed and some examples of things that are not allowed as an aid to understanding what "static variable reference" means.