### PR TITLE
Expect correct type from a conditional with nulls

### DIFF
--- a/hcl/hclsyntax/expression_test.go
+++ b/hcl/hclsyntax/expression_test.go
@@ -1351,6 +1351,56 @@ EOT
 			cty.False,
 			0,
 		},
+		{
+			`true ? var : null`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"var": cty.ObjectVal(map[string]cty.Value{"a": cty.StringVal("A")}),
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{"a": cty.StringVal("A")}),
+			0,
+		},
+		{
+			`true ? var : null`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"var": cty.UnknownVal(cty.DynamicPseudoType),
+				},
+			},
+			cty.UnknownVal(cty.DynamicPseudoType),
+			0,
+		},
+		{
+			`true ? ["a", "b"] : null`,
+			nil,
+			cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+			0,
+		},
+		{
+			`true ? null: ["a", "b"]`,
+			nil,
+			cty.NullVal(cty.Tuple([]cty.Type{cty.String, cty.String})),
+			0,
+		},
+		{
+			`false ? ["a", "b"] : null`,
+			nil,
+			cty.NullVal(cty.Tuple([]cty.Type{cty.String, cty.String})),
+			0,
+		},
+		{
+			`false ? null: ["a", "b"]`,
+			nil,
+			cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+			0,
+		},
+		{
+			`false ? null: null`,
+			nil,
+			cty.NullVal(cty.DynamicPseudoType),
+			0,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The type unification done when evaluating a conditional normally needs
to return a DynamicPseudoType when either condition is dynamic. However,
a null dynamic value represents a known value of the desired type rather
than an unknown type, and we can be certain that it is convertible to
the desired type during the final evaluation.  Rather than unifying
types against nulls, directly assign the needed conversion when
evaluating the conditional.