### PR TITLE
ensure correct type in conditionals w/ DynamicVal

### DIFF
--- a/hcl/hclsyntax/expression_test.go
+++ b/hcl/hclsyntax/expression_test.go
@@ -1401,6 +1401,51 @@ EOT
 			cty.NullVal(cty.DynamicPseudoType),
 			0,
 		},
+		{
+			`false ? var: {a = "b"}`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"var": cty.DynamicVal,
+				},
+			},
+			cty.ObjectVal(map[string]cty.Value{
+				"a": cty.StringVal("b"),
+			}),
+			0,
+		},
+		{
+			`true ? ["a", "b"]: var`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"var": cty.UnknownVal(cty.DynamicPseudoType),
+				},
+			},
+			cty.TupleVal([]cty.Value{
+				cty.StringVal("a"),
+				cty.StringVal("b"),
+			}),
+			0,
+		},
+		{
+			`false ? ["a", "b"]: var`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"var": cty.DynamicVal,
+				},
+			},
+			cty.DynamicVal,
+			0,
+		},
+		{
+			`false ? ["a", "b"]: var`,
+			&hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"var": cty.UnknownVal(cty.DynamicPseudoType),
+				},
+			},
+			cty.DynamicVal,
+			0,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
If an expression in a conditional contains a DynamicVal, we know that
the opposing condition can pass through with no conversion since
converting to a DynamicPseudoType is a noop. We can also just pass
through the Dynamic val, since it is unknown and can't be converted.