### PR TITLE
Remove incorrect quotes around types in examples

### DIFF
--- a/cmd/hcldec/spec-format.md
+++ b/cmd/hcldec/spec-format.md
@@ -41,12 +41,12 @@ spec blocks:
 ```hcl
 object {
   attr "name" {
-    type = "string"
+    type = string
   }
   block "address" {
     object {
       attr "street" {
-        type = "string"
+        type = string
       }
       # ...
     }
@@ -73,11 +73,11 @@ any nested spec blocks:
 array {
   attr {
     name = "first_element"
-    type = "string"
+    type = string
   }
   attr {
     name = "second_element"
-    type = "string"
+    type = string
   }
 }
 ```


### PR DESCRIPTION
When I tried a spec with quoted types, I got this error:
`A type is required, not string.`

Later in the document, the types don’t have quotes, so I figured that’s what’s expected.