### PR TITLE
gohcl: retain blocks while decoding

### DIFF
--- a/gohcl/decode.go
+++ b/gohcl/decode.go
@@ -147,7 +147,9 @@ func decodeBodyToStruct(body hcl.Body, ctx *hcl.EvalContext, val reflect.Value) 
 
 		if len(blocks) == 0 {
 			if isSlice || isPtr {
-				val.Field(fieldIdx).Set(reflect.Zero(field.Type))
+				if val.Field(fieldIdx).IsNil() {
+					val.Field(fieldIdx).Set(reflect.Zero(field.Type))
+				}
 			} else {
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
@@ -166,11 +168,20 @@ func decodeBodyToStruct(body hcl.Body, ctx *hcl.EvalContext, val reflect.Value) 
 			if isPtr {
 				elemType = reflect.PtrTo(ty)
 			}
-			sli := reflect.MakeSlice(reflect.SliceOf(elemType), len(blocks), len(blocks))
+			sli := val.Field(fieldIdx)
+			if sli.IsNil() {
+				sli = reflect.MakeSlice(reflect.SliceOf(elemType), len(blocks), len(blocks))
+			}
 
 			for i, block := range blocks {
 				if isPtr {
-					v := reflect.New(ty)
+					if i >= sli.Len() {
+						sli = reflect.Append(sli, reflect.New(ty))
+					}
+					v := sli.Index(i)
+					if v.IsNil() {
+						v = reflect.New(ty)
+					}
 					diags = append(diags, decodeBlockToValue(block, ctx, v.Elem())...)
 					sli.Index(i).Set(v)
 				} else {
@@ -183,7 +194,10 @@ func decodeBodyToStruct(body hcl.Body, ctx *hcl.EvalContext, val reflect.Value) 
 		default:
 			block := blocks[0]
 			if isPtr {
-				v := reflect.New(ty)
+				v := val.Field(fieldIdx)
+				if v.IsNil() {
+					v = reflect.New(ty)
+				}
 				diags = append(diags, decodeBlockToValue(block, ctx, v.Elem())...)
 				val.Field(fieldIdx).Set(v)
 			} else {


### PR DESCRIPTION
Currently, if non-empty struct is passed to DecodeBody function,
decoding process will keep already initialized string fields values or
overwrite them, if they are specified in HCL. This behaviour is useful,
as it allows to have some default values for fields.

However, if the field is a block or multiple blocks (slice), then the
entire block is overwritten, which erases the struct. Because of that,
settings default values in nested structs is not possible.

Consider following HCL and struct example:
```
foo "foo" {
  nested {
    more = "foo"
  }
}

foo := &Foo{
  Plain: "foo",
  Nested: &Bar{
    Plain: "bar",
  },
}
```
The result will become:
```
foo := &Foo{
  Plain: "foo",
  Nested: &Bar{
    More: "foo",
  },
}
```
With this commit, decode functions will check will check if the value is
nil and only then set them to empty struct, which allows for appending
to existing structs.

In case of a slice, either new empty element will be added, or existing
element will be used for setting new value.

Result after this patch:
```
foo := &Foo{
  Plain: "foo",
  Nested: &Bar{
    More: "foo",
    Plain: "bar,
  },
}
```
While it is not very useful for slices, since default values would have
to be positional, it is useful for standalone blocks and it makes
decoding process to behave more consistent.

Alternative to this patch would be always zeroing top-level struct when
decode process starts, to maintain clear and consistent behaviour.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>