### PR TITLE
 hclwrite: Fix heredocs never close during format

### DIFF
--- a/hclwrite/format.go
+++ b/hclwrite/format.go
@@ -382,34 +382,14 @@ func linesForFormat(tokens Tokens) []formatLine {
 
 	// Now we'll pick off any trailing comments and attribute assignments
 	// to shuffle off into the "comment" and "assign" cells.
-	inHeredoc := false
 	for i := range lines {
 		line := &lines[i]
+
 		if len(line.lead) == 0 {
 			// if the line is empty then there's nothing for us to do
 			// (this should happen only for the final line, because all other
 			// lines would have a newline token of some kind)
 			continue
-		}
-
-		if inHeredoc {
-			for _, tok := range line.lead {
-				if tok.Type == hclsyntax.TokenCHeredoc {
-					inHeredoc = false
-					break
-				}
-			}
-			// Inside a heredoc everything is "lead", even if there's a
-			// template interpolation embedded in there that might otherwise
-			// confuse our logic below.
-			continue
-		}
-
-		for _, tok := range line.lead {
-			if tok.Type == hclsyntax.TokenOHeredoc {
-				inHeredoc = true
-				break
-			}
 		}
 
 		if len(line.lead) > 1 && line.lead[len(line.lead)-1].Type == hclsyntax.TokenComment {

--- a/hclwrite/format_test.go
+++ b/hclwrite/format_test.go
@@ -580,6 +580,30 @@ bar {
 }
 `,
 		},
+		{
+			`
+module "foo" {
+foo = <<EOF
+5
+EOF
+}
+
+module "x" {
+a = "b"
+abcde = "456"
+}`,
+			`
+module "foo" {
+  foo = <<EOF
+5
+EOF
+}
+
+module "x" {
+  a     = "b"
+  abcde = "456"
+}`,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Fix for hashicorp/terraform#21434.

Currently `linesForFormat()` waits for `TokenCHeredoc` to appear in a different line after finding `TokenOHeredoc`. It never happens, however, since `scanTokens()` does not produce `TokenNewline` inside heredocs so all tokens between `TokenOHeredoc` and `TokenCHeredoc` are put inside the same line.
Incorrect eq sign alignment happened because inHeredoc flag never set back to `false` then the following `line.assign` calculations were skipped.
