### PR TITLE
Add test cases for multiline heredocs

### DIFF
--- a/hcl/hclsyntax/expression_test.go
+++ b/hcl/hclsyntax/expression_test.go
@@ -1269,6 +1269,36 @@ EOT
 			cty.TupleVal([]cty.Value{cty.StringVal("  Foo\n  Bar\n  Baz\n")}),
 			0,
 		},
+		{
+			`[
+  <<EOT
+  Foo
+
+  Bar
+
+  Baz
+  EOT
+]
+`,
+			nil,
+			cty.TupleVal([]cty.Value{cty.StringVal("  Foo\n\n  Bar\n\n  Baz\n")}),
+			0,
+		},
+		{
+			`[
+  <<-EOT
+  Foo
+
+  Bar
+
+  Baz
+  EOT
+]
+`,
+			nil,
+			cty.TupleVal([]cty.Value{cty.StringVal("Foo\n\nBar\n\nBaz\n")}),
+			0,
+		},
 
 		{
 			`unk["baz"]`,

--- a/specsuite/tests/expressions/heredoc.hcl
+++ b/specsuite/tests/expressions/heredoc.hcl
@@ -19,6 +19,20 @@ EOT
     ${bar}
     Baz
   EOT
+  newlines_between = <<EOT
+Foo
+
+Bar
+
+Baz
+EOT
+  indented_newlines_between = <<EOT
+    Foo
+
+    Bar
+
+    Baz
+  EOT
 
   marker_at_suffix = <<EOT
     NOT EOT
@@ -68,6 +82,20 @@ EOT
   unicode_spaces = <<-EOT
      Foo (there's two "em spaces" before Foo there)
     Bar
+    Baz
+  EOT
+  newlines_between = <<-EOT
+Foo
+
+Bar
+
+Baz
+EOT
+  indented_newlines_between = <<-EOT
+    Foo
+
+    Bar
+
     Baz
   EOT
 }

--- a/specsuite/tests/expressions/heredoc.t
+++ b/specsuite/tests/expressions/heredoc.t
@@ -4,6 +4,8 @@ result = {
         indented      = "    Foo\n    Bar\n    Baz\n"
         indented_more = "    Foo\n      Bar\n    Baz\n"
         interp        = "    Foo\n    Bar\n    Baz\n"
+        newlines_between = "Foo\n\nBar\n\nBaz\n"
+        indented_newlines_between = "    Foo\n\n    Bar\n\n    Baz\n"
 
         marker_at_suffix = "    NOT EOT\n"
     }
@@ -17,6 +19,8 @@ result = {
         interp_indented_less = "  Foo\n  Bar\n  Baz\n"
         tabs                 = "Foo\n Bar\n Baz\n"
         unicode_spaces       = " Foo (there's two \"em spaces\" before Foo there)\nBar\nBaz\n"
+        newlines_between     = "Foo\n\nBar\n\nBaz\n"
+        indented_newlines_between = "Foo\n\nBar\n\nBaz\n"
     }
 }
 result_type = object({


### PR DESCRIPTION
>These tests pass, but they close what's effectively a gap in the test
>coverage wherein nothing was ensuring that the whitespace prefix
>trimming behavior still gave the same/correct output with blank lines
>in the middle.

>I made these tests because nomad templates were behaving oddly, only
>to discover that nomad has a mix of both hcl1 and hcl2 in it!
>Fortunately, hcl2's behavior is correct, but it should stay that way.