### PR TITLE
hclwrite: Do not add spaces before TokenTemplateControl

### DIFF
--- a/hclwrite/format.go
+++ b/hclwrite/format.go
@@ -317,7 +317,7 @@ func spaceAfterToken(subject, before, after *Token) bool {
 		return true
 
 	// Don't add spaces between interpolated items
-	case subject.Type == hclsyntax.TokenTemplateSeqEnd && after.Type == hclsyntax.TokenTemplateInterp:
+	case subject.Type == hclsyntax.TokenTemplateSeqEnd && (after.Type == hclsyntax.TokenTemplateInterp || after.Type == hclsyntax.TokenTemplateControl):
 		return false
 
 	case tokenBracketChange(subject) > 0:

--- a/hclwrite/format_test.go
+++ b/hclwrite/format_test.go
@@ -80,6 +80,10 @@ func TestFormat(t *testing.T) {
 			`a = "${b}${c}${d} ${e}"`,
 		},
 		{
+			`"%{if true}${var.foo}%{endif}"`,
+			`"%{if true}${var.foo}%{endif}"`,
+		},
+		{
 			`b{}`,
 			`b {}`,
 		},


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/22356

If we format the following code, will get the following results:

**input**
```hcl
"%{if true}${var.foo}%{endif}"
```

**result**
```hcl
"%{if true}${var.foo} %{endif}"
```

This is a different string, so do not add a space before the `%{`. This pull request changes the handling of `TokenTemplateControl` token to avoid adding an extra space.
