### PR TITLE
hclwrite: Allow body to set attributes in blocks

### DIFF
--- a/hcl/hclsyntax/parser.go
+++ b/hcl/hclsyntax/parser.go
@@ -1651,7 +1651,7 @@ Token:
 			break Token
 
 		case TokenQuotedLit:
-			s, sDiags := p.decodeStringLit(tok)
+			s, sDiags := ParseStringLiteralToken(tok)
 			diags = append(diags, sDiags...)
 			ret.WriteString(s)
 
@@ -1711,13 +1711,13 @@ Token:
 	return ret.String(), hcl.RangeBetween(oQuote.Range, cQuote.Range), diags
 }
 
-// decodeStringLit processes the given token, which must be either a
+// ParseStringLiteralToken processes the given token, which must be either a
 // TokenQuotedLit or a TokenStringLit, returning the string resulting from
 // resolving any escape sequences.
 //
 // If any error diagnostics are returned, the returned string may be incomplete
 // or otherwise invalid.
-func (p *parser) decodeStringLit(tok Token) (string, hcl.Diagnostics) {
+func ParseStringLiteralToken(tok Token) (string, hcl.Diagnostics) {
 	var quoted bool
 	switch tok.Type {
 	case TokenQuotedLit:
@@ -1725,7 +1725,7 @@ func (p *parser) decodeStringLit(tok Token) (string, hcl.Diagnostics) {
 	case TokenStringLit:
 		quoted = false
 	default:
-		panic("decodeQuotedLit can only be used with TokenStringLit and TokenQuotedLit tokens")
+		panic("ParseStringLiteralToken can only be used with TokenStringLit and TokenQuotedLit tokens")
 	}
 	var diags hcl.Diagnostics
 

--- a/hcl/hclsyntax/parser_template.go
+++ b/hcl/hclsyntax/parser_template.go
@@ -383,7 +383,7 @@ Token:
 
 		switch next.Type {
 		case TokenStringLit, TokenQuotedLit:
-			str, strDiags := p.decodeStringLit(next)
+			str, strDiags := ParseStringLiteralToken(next)
 			diags = append(diags, strDiags...)
 
 			if ltrim {

--- a/hclwrite/ast_block.go
+++ b/hclwrite/ast_block.go
@@ -87,8 +87,6 @@ func (b *Block) Labels() []string {
 	for _, label := range list {
 		switch labelObj := label.content.(type) {
 		case *identifier:
-			// If label is unquoted, we expect to come here,
-			// but the current implementation seems to always quote it and never reach here.
 			if labelObj.token.Type == hclsyntax.TokenIdent {
 				labelString := string(labelObj.token.Bytes)
 				labelNames = append(labelNames, labelString)
@@ -96,14 +94,6 @@ func (b *Block) Labels() []string {
 
 		case *quoted:
 			tokens := labelObj.tokens
-
-			// FIXME: A workaround for unquoted case
-			// TokenIdent should be *idenifier, but the current implementation seems to wrap it in *quoted.
-			if len(tokens) == 1 && tokens[0].Type == hclsyntax.TokenIdent {
-				labelString := string(tokens[0].Bytes)
-				labelNames = append(labelNames, labelString)
-			}
-
 			if len(tokens) == 3 &&
 				tokens[0].Type == hclsyntax.TokenOQuote &&
 				tokens[1].Type == hclsyntax.TokenQuotedLit &&

--- a/hclwrite/ast_block.go
+++ b/hclwrite/ast_block.go
@@ -87,6 +87,8 @@ func (b *Block) Labels() []string {
 	for _, label := range list {
 		switch labelObj := label.content.(type) {
 		case *identifier:
+			// If label is unquoted, we expect to come here,
+			// but the current implementation seems to always quote it and never reach here.
 			if labelObj.token.Type == hclsyntax.TokenIdent {
 				labelString := string(labelObj.token.Bytes)
 				labelNames = append(labelNames, labelString)
@@ -94,6 +96,14 @@ func (b *Block) Labels() []string {
 
 		case *quoted:
 			tokens := labelObj.tokens
+
+			// FIXME: A workaround for unquoted case
+			// TokenIdent should be *idenifier, but the current implementation seems to wrap it in *quoted.
+			if len(tokens) == 1 && tokens[0].Type == hclsyntax.TokenIdent {
+				labelString := string(tokens[0].Bytes)
+				labelNames = append(labelNames, labelString)
+			}
+
 			if len(tokens) == 3 &&
 				tokens[0].Type == hclsyntax.TokenOQuote &&
 				tokens[1].Type == hclsyntax.TokenQuotedLit &&

--- a/hclwrite/ast_block.go
+++ b/hclwrite/ast_block.go
@@ -1,6 +1,8 @@
 package hclwrite
 
 import (
+	"strings"
+
 	"github.com/hashicorp/hcl2/hcl/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -71,4 +73,24 @@ func (b *Block) init(typeName string, labels []string) {
 // tokens that are generated between the blocks open and close braces.
 func (b *Block) Body() *Body {
 	return b.body.content.(*Body)
+}
+
+// Type returns the type name of the block.
+func (b *Block) Type() string {
+	typeNameObj := b.typeName.content.(*identifier)
+	return string(typeNameObj.token.Bytes)
+}
+
+// Labels returns the labels of the block.
+func (b *Block) Labels() []string {
+	labelNames := make([]string, 0, len(b.labels))
+	list := b.labels.List()
+	for _, label := range list {
+		labelObj := label.content.(*quoted)
+		labelString := string(labelObj.tokens.Bytes())
+		// The labelString contains spaces and quotes. we should remove them.
+		trimmed := strings.Trim(labelString, ` "`)
+		labelNames = append(labelNames, trimmed)
+	}
+	return labelNames
 }

--- a/hclwrite/ast_block_test.go
+++ b/hclwrite/ast_block_test.go
@@ -1,0 +1,105 @@
+package hclwrite
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl2/hcl"
+)
+
+func TestBlockType(t *testing.T) {
+	tests := []struct {
+		src  string
+		want string
+	}{
+		{
+			`
+service {
+  attr0 = "val0"
+}
+`,
+			"service",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s", test.want), func(t *testing.T) {
+			f, diags := ParseConfig([]byte(test.src), "", hcl.Pos{Line: 1, Column: 1})
+			if len(diags) != 0 {
+				for _, diag := range diags {
+					t.Logf("- %s", diag.Error())
+				}
+				t.Fatalf("unexpected diagnostics")
+			}
+
+			block := f.Body().Blocks()[0]
+			got := string(block.Type())
+			if got != test.want {
+				t.Errorf("wrong result\ngot:  %s\nwant: %s", got, test.want)
+			}
+		})
+	}
+}
+
+func TestBlockLabels(t *testing.T) {
+	tests := []struct {
+		src  string
+		want []string
+	}{
+		{
+			`
+nolabel {
+}
+`,
+			[]string{},
+		},
+		{
+			`
+quoted "label1" {
+}
+`,
+			[]string{"label1"},
+		},
+		{
+			`
+quoted "label1" "label2" {
+}
+`,
+			[]string{"label1", "label2"},
+		},
+		{
+			`
+unquoted label1 {
+}
+`,
+			[]string{"label1"},
+		},
+		{
+			`
+escape "\u0041" {
+}
+`,
+			[]string{"\u0041"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s", strings.Join(test.want, " ")), func(t *testing.T) {
+			f, diags := ParseConfig([]byte(test.src), "", hcl.Pos{Line: 1, Column: 1})
+			if len(diags) != 0 {
+				for _, diag := range diags {
+					t.Logf("- %s", diag.Error())
+				}
+				t.Fatalf("unexpected diagnostics")
+			}
+
+			block := f.Body().Blocks()[0]
+			got := block.Labels()
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.want)
+			}
+		})
+	}
+}

--- a/hclwrite/ast_body.go
+++ b/hclwrite/ast_body.go
@@ -2,7 +2,6 @@ package hclwrite
 
 import (
 	"reflect"
-	"strings"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/hcl2/hcl/hclsyntax"
@@ -89,23 +88,12 @@ func (b *Body) GetAttribute(name string) *Attribute {
 // given name and labels or returns nil if there is currently no matching
 // block.
 func (b *Body) FirstMatchingBlock(typeName string, labels []string) *Block {
-	for n := range b.items {
-		if block, isBlock := n.content.(*Block); isBlock {
-			typeNameObj := block.typeName.content.(*identifier)
-			if typeNameObj.hasName(typeName) {
-				labelNames := make([]string, 0, len(labels))
-				list := block.labels.List()
-				for _, label := range list {
-					labelObj := label.content.(*quoted)
-					labelString := string(labelObj.tokens.Bytes())
-					// The labelString contains spaces and quotes. we should remove them.
-					trimmed := strings.Trim(labelString, ` "`)
-					labelNames = append(labelNames, trimmed)
-				}
-				if reflect.DeepEqual(labels, labelNames) {
-					// We've found it!
-					return block
-				}
+	for _, block := range b.Blocks() {
+		if typeName == block.Type() {
+			labelNames := block.Labels()
+			if reflect.DeepEqual(labels, labelNames) {
+				// We've found it!
+				return block
 			}
 		}
 	}

--- a/hclwrite/ast_body.go
+++ b/hclwrite/ast_body.go
@@ -85,9 +85,10 @@ func (b *Body) GetAttribute(name string) *Attribute {
 	return nil
 }
 
-// GetBlock returns the block from the body that has the given name,
-// and labels or returns nil if there is currently no matching block.
-func (b *Body) GetBlock(typeName string, labels []string) *Block {
+// FirstMatchingBlock returns a first matching block from the body that has the
+// given name and labels or returns nil if there is currently no matching
+// block.
+func (b *Body) FirstMatchingBlock(typeName string, labels []string) *Block {
 	for n := range b.items {
 		if block, isBlock := n.content.(*Block); isBlock {
 			typeNameObj := block.typeName.content.(*identifier)

--- a/hclwrite/ast_body_test.go
+++ b/hclwrite/ast_body_test.go
@@ -3,6 +3,7 @@ package hclwrite
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -210,6 +211,131 @@ func TestBodyGetAttribute(t *testing.T) {
 				got := attr.BuildTokens(nil)
 				if !reflect.DeepEqual(got, test.want) {
 					t.Errorf("wrong result\ngot:  %s\nwant: %s", spew.Sdump(got), spew.Sdump(test.want))
+				}
+			}
+		})
+	}
+}
+
+func TestBodyGetBlock(t *testing.T) {
+	src := `a = "b"
+service {
+  attr0 = "val0"
+}
+service "label1" {
+  attr1 = "val1"
+}
+service "label1" "label2" {
+  attr2 = "val2"
+}
+parent {
+  attr3 = "val3"
+  child {
+    attr4 = "val4"
+  }
+}
+`
+
+	tests := []struct {
+		src      string
+		typeName string
+		labels   []string
+		want     string
+	}{
+		{
+			src,
+			"service",
+			[]string{},
+			`service {
+  attr0 = "val0"
+}
+`,
+		},
+		{
+			src,
+			"service",
+			[]string{"label1"},
+			`service "label1" {
+  attr1 = "val1"
+}
+`,
+		},
+		{
+			src,
+			"service",
+			[]string{"label1", "label2"},
+			`service "label1" "label2" {
+  attr2 = "val2"
+}
+`,
+		},
+		{
+			src,
+			"parent",
+			[]string{},
+			`parent {
+  attr3 = "val3"
+  child {
+    attr4 = "val4"
+  }
+}
+`,
+		},
+		{
+			src,
+			"hoge",
+			[]string{},
+			"",
+		},
+		{
+			src,
+			"hoge",
+			[]string{"label1"},
+			"",
+		},
+		{
+			src,
+			"service",
+			[]string{"label2"},
+			"",
+		},
+		{
+			src,
+			"service",
+			[]string{"label2", "label1"},
+			"",
+		},
+		{
+			src,
+			"child",
+			[]string{},
+			"",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s %s", test.typeName, strings.Join(test.labels, " ")), func(t *testing.T) {
+			f, diags := ParseConfig([]byte(test.src), "", hcl.Pos{Line: 1, Column: 1})
+			if len(diags) != 0 {
+				for _, diag := range diags {
+					t.Logf("- %s", diag.Error())
+				}
+				t.Fatalf("unexpected diagnostics")
+			}
+
+			block := f.Body().GetBlock(test.typeName, test.labels)
+			if block == nil {
+				if test.want != "" {
+					t.Fatal("block not found, but want it to exist")
+				}
+			} else {
+				if test.want == "" {
+					t.Fatal("block found, but expecting not found")
+				}
+
+				got := string(block.BuildTokens(nil).Bytes())
+				if got != test.want {
+					t.Errorf("wrong result\ngot:  %s\nwant: %s", got, test.want)
 				}
 			}
 		})
@@ -635,6 +761,109 @@ func TestBodySetAttributeTraversal(t *testing.T) {
 			if !reflect.DeepEqual(got, test.want) {
 				diff := cmp.Diff(test.want, got)
 				t.Errorf("wrong result\ngot:  %s\nwant: %s\ndiff:\n%s", spew.Sdump(got), spew.Sdump(test.want), diff)
+			}
+		})
+	}
+}
+
+func TestBodySetAttributeValueInBlock(t *testing.T) {
+	src := `service "label1" {
+  attr1 = "val1"
+}
+`
+	tests := []struct {
+		src      string
+		typeName string
+		labels   []string
+		attr     string
+		val      cty.Value
+		want     string
+	}{
+		{
+			src,
+			"service",
+			[]string{"label1"},
+			"attr1",
+			cty.StringVal("updated1"),
+			`service "label1" {
+  attr1 = "updated1"
+}
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s = %#v in %s %s", test.attr, test.val, test.typeName, strings.Join(test.labels, " ")), func(t *testing.T) {
+			f, diags := ParseConfig([]byte(test.src), "", hcl.Pos{Line: 1, Column: 1})
+			if len(diags) != 0 {
+				for _, diag := range diags {
+					t.Logf("- %s", diag.Error())
+				}
+				t.Fatalf("unexpected diagnostics")
+			}
+
+			b := f.Body().GetBlock(test.typeName, test.labels)
+			b.Body().SetAttributeValue(test.attr, test.val)
+			tokens := f.BuildTokens(nil)
+			format(tokens)
+			got := string(tokens.Bytes())
+			if got != test.want {
+				t.Errorf("wrong result\ngot:  %s\nwant: %s\n", got, test.want)
+			}
+		})
+	}
+}
+
+func TestBodySetAttributeValueInNestedBlock(t *testing.T) {
+	src := `parent {
+  attr1 = "val1"
+  child {
+    attr2 = "val2"
+  }
+}
+`
+	tests := []struct {
+		src            string
+		parentTypeName string
+		childTypeName  string
+		attr           string
+		val            cty.Value
+		want           string
+	}{
+		{
+			src,
+			"parent",
+			"child",
+			"attr2",
+			cty.StringVal("updated2"),
+			`parent {
+  attr1 = "val1"
+  child {
+    attr2 = "updated2"
+  }
+}
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s = %#v in %s in %s", test.attr, test.val, test.childTypeName, test.parentTypeName), func(t *testing.T) {
+			f, diags := ParseConfig([]byte(test.src), "", hcl.Pos{Line: 1, Column: 1})
+			if len(diags) != 0 {
+				for _, diag := range diags {
+					t.Logf("- %s", diag.Error())
+				}
+				t.Fatalf("unexpected diagnostics")
+			}
+
+			parent := f.Body().GetBlock(test.parentTypeName, []string{})
+			child := parent.Body().GetBlock(test.childTypeName, []string{})
+			child.Body().SetAttributeValue(test.attr, test.val)
+			tokens := f.BuildTokens(nil)
+			format(tokens)
+			got := string(tokens.Bytes())
+			if got != test.want {
+				t.Errorf("wrong result\ngot:  %s\nwant: %s\n", got, test.want)
 			}
 		})
 	}

--- a/hclwrite/ast_body_test.go
+++ b/hclwrite/ast_body_test.go
@@ -217,7 +217,7 @@ func TestBodyGetAttribute(t *testing.T) {
 	}
 }
 
-func TestBodyGetBlock(t *testing.T) {
+func TestBodyFirstMatchingBlock(t *testing.T) {
 	src := `a = "b"
 service {
   attr0 = "val0"
@@ -323,7 +323,7 @@ parent {
 				t.Fatalf("unexpected diagnostics")
 			}
 
-			block := f.Body().GetBlock(test.typeName, test.labels)
+			block := f.Body().FirstMatchingBlock(test.typeName, test.labels)
 			if block == nil {
 				if test.want != "" {
 					t.Fatal("block not found, but want it to exist")
@@ -802,7 +802,7 @@ func TestBodySetAttributeValueInBlock(t *testing.T) {
 				t.Fatalf("unexpected diagnostics")
 			}
 
-			b := f.Body().GetBlock(test.typeName, test.labels)
+			b := f.Body().FirstMatchingBlock(test.typeName, test.labels)
 			b.Body().SetAttributeValue(test.attr, test.val)
 			tokens := f.BuildTokens(nil)
 			format(tokens)
@@ -856,8 +856,8 @@ func TestBodySetAttributeValueInNestedBlock(t *testing.T) {
 				t.Fatalf("unexpected diagnostics")
 			}
 
-			parent := f.Body().GetBlock(test.parentTypeName, []string{})
-			child := parent.Body().GetBlock(test.childTypeName, []string{})
+			parent := f.Body().FirstMatchingBlock(test.parentTypeName, []string{})
+			child := parent.Body().FirstMatchingBlock(test.childTypeName, []string{})
 			child.Body().SetAttributeValue(test.attr, test.val)
 			tokens := f.BuildTokens(nil)
 			format(tokens)


### PR DESCRIPTION
The current implementation can set attributes in top-level, but not attributes in blocks.
To do this, add the `(*Body).GetBlock()` method that selects a block by typeName and labels.

Related to #88

---
UPDATE: The original proposal has changed as a result of the suggestion:

- Add `(*Block).Type()` and `(*Block).Labels()`
- Add `(*Body).FirstMatchingBlock()` instead of `(*Body).GetBlock()`
- Expose `parser.decodeStringLit()` in the `hclsyntax` package as `ParseStringLiteralToken()`