### PR TITLE
hclwrite: Fix unquoted label to be parsed as `*identifier`

### DIFF
--- a/hclwrite/parser.go
+++ b/hclwrite/parser.go
@@ -307,7 +307,12 @@ func parseBlock(nativeBlock *hclsyntax.Block, from, leadComments, lineComments, 
 		before, labelTokens, from = from.Partition(rng)
 		children.AppendUnstructuredTokens(before.Tokens())
 		tokens := labelTokens.Tokens()
-		ln := newNode(newQuoted(tokens))
+		var ln *node
+		if len(tokens) == 1 && tokens[0].Type == hclsyntax.TokenIdent {
+			ln = newNode(newIdentifier(tokens[0]))
+		} else {
+			ln = newNode(newQuoted(tokens))
+		}
 		block.labels.Add(ln)
 		children.AppendNode(ln)
 	}

--- a/hclwrite/parser_test.go
+++ b/hclwrite/parser_test.go
@@ -225,6 +225,84 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			"b label {}\n",
+			TestTreeNode{
+				Type: "Body",
+				Children: []TestTreeNode{
+					{
+						Type: "Block",
+						Children: []TestTreeNode{
+							{
+								Type: "comments",
+							},
+							{
+								Type: "identifier",
+								Val:  "b",
+							},
+							{
+								Type: "identifier",
+								Val:  ` label`,
+							},
+							{
+								Type: "Tokens",
+								Val:  " {",
+							},
+							{
+								Type: "Body",
+							},
+							{
+								Type: "Tokens",
+								Val:  "}",
+							},
+							{
+								Type: "Tokens",
+								Val:  "\n",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"b \"label\" {}\n",
+			TestTreeNode{
+				Type: "Body",
+				Children: []TestTreeNode{
+					{
+						Type: "Block",
+						Children: []TestTreeNode{
+							{
+								Type: "comments",
+							},
+							{
+								Type: "identifier",
+								Val:  "b",
+							},
+							{
+								Type: "quoted",
+								Val:  ` "label"`,
+							},
+							{
+								Type: "Tokens",
+								Val:  " {",
+							},
+							{
+								Type: "Body",
+							},
+							{
+								Type: "Tokens",
+								Val:  "}",
+							},
+							{
+								Type: "Tokens",
+								Val:  "\n",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			"b {\n  a = 1\n}\n",
 			TestTreeNode{
 				Type: "Body",


### PR DESCRIPTION
Fix an issue found while working on #126.

If label is unquoted, we expect to get a TokenIdent as `*identifier`, but the current implementation seems to wrap it in `*quoted`.

We should handle this case correctly.