### PR TITLE
Testing: Use Go modules and Start testing with go versions 1.11.x 1.12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: go
 
 go:
-  - 1.9.x
+  - 1.11.x
+  - 1.12.x
+
+env:
+  - GO111MODULE=on
 
 before_install:
-  - go get -t -v ./...
+  - go get -v ./...
 
 script:
   - ./.travis.sh


### PR DESCRIPTION
Library the `master` branch of `kylelemons/godebug` is unsupportive of Go version 1.9.x since `https://github.com/kylelemons/godebug/commit/bde9f3c96d7aa052631925fa03b944627a335ff`.

Travis is set to Go version 1.9.x hence it's not using Go modules (introduced in Go 1.11.x) and thus retrieving master of all dependencies when running `go get`.

This PR enables Travis to test with Go versions 1.11.x and 1.12.x, and starts using Go modules when testing.